### PR TITLE
Remove unused imports

### DIFF
--- a/src/mcp-sse-plugin.test.ts
+++ b/src/mcp-sse-plugin.test.ts
@@ -1,11 +1,10 @@
 import { Server } from "@modelcontextprotocol/sdk/server/index";
 import fastify from "fastify";
-import { fastifyMCPSSE } from "./mcp-sse-plugin";
-import { Readable } from "node:stream";
 import { randomUUID } from "node:crypto";
+import { Readable } from "node:stream";
+import { setImmediate } from "node:timers/promises";
+import { fastifyMCPSSE } from "./mcp-sse-plugin";
 import { Sessions } from "./session-storage";
-import { setTimeout, setImmediate } from "node:timers/promises";
-import { finished } from "node:stream/promises";
 
 describe(fastifyMCPSSE.name, () => {
   it("should handle SSE connections successfully", async () => {


### PR DESCRIPTION
Removes unused imports in a test file. Should setup CI and make this an ESLint error to avoid this problem in the future.

