### PR TITLE
Fix typescript version in editor to remove import errors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/src/mcp-sse-plugin.test.ts
+++ b/src/mcp-sse-plugin.test.ts
@@ -1,4 +1,4 @@
-import { Server } from "@modelcontextprotocol/sdk/server/index";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import fastify from "fastify";
 import { randomUUID } from "node:crypto";
 import { Readable } from "node:stream";


### PR DESCRIPTION
Adds a .js extension to the MCP server import, and adds a config for VSCode to use the workspace's version of typescript

