### PR TITLE
Fix import extensions for MCP sdk

### DIFF
--- a/src/mcp-sse-plugin.ts
+++ b/src/mcp-sse-plugin.ts
@@ -1,5 +1,5 @@
-import type { Server } from "@modelcontextprotocol/sdk/server/index";
-import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse";
+import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { FastifyPluginCallback, FastifyRequest } from "fastify";
 import { Sessions } from "./session-storage";
 

--- a/src/session-storage.ts
+++ b/src/session-storage.ts
@@ -1,4 +1,4 @@
-import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 
 export class Sessions {
   private readonly sessions: Map<string, SSEServerTransport>;


### PR DESCRIPTION
Fixes the error thrown by Node when importing this package in a non ESM project.

