### PR TITLE
Make session storage iterable

### DIFF
--- a/src/session-storage.test.ts
+++ b/src/session-storage.test.ts
@@ -116,6 +116,16 @@ describe(Sessions.name, () => {
     expect(thrownValue).toBeInstanceOf(Error);
     expect((thrownValue as Error).message).toBe("test");
   });
+
+  it("should be iterable", () => {
+    const sessions = new Sessions();
+    const sessionId = "123";
+
+    sessions.add(sessionId, fakeTransport());
+    sessions.add("456", fakeTransport());
+
+    expect(Array.from(sessions)).toHaveLength(2);
+  });
 });
 
 function fakeTransport(): SSEServerTransport {

--- a/src/session-storage.ts
+++ b/src/session-storage.ts
@@ -7,7 +7,10 @@ type SessionEvents = {
   error: [unknown];
 };
 
-export class Sessions extends EventEmitter<SessionEvents> {
+export class Sessions
+  extends EventEmitter<SessionEvents>
+  implements Iterable<SSEServerTransport>
+{
   private readonly sessions: Map<string, SSEServerTransport>;
 
   constructor() {
@@ -35,5 +38,9 @@ export class Sessions extends EventEmitter<SessionEvents> {
 
   get count() {
     return this.sessions.size;
+  }
+
+  [Symbol.iterator]() {
+    return this.sessions.values();
   }
 }


### PR DESCRIPTION
Makes the `Sessions` class iterable by implementing the `[Symbol.iterable]` property.
Useful for dealing with all sessions managed by this class, e.g., for handling graceful shutdown.

```ts
const sessions = new Sessions();

process.on("SIGINT", () => {
    Promise.all(Array.from(sessions).map(s => s.close())
        .then(() => {
            logger.info("Closed all active sessions");
        })
        .catch(error => {
            logger.error(error);
        });
})
```
