### PR TITLE
Pass-auth-token

### DIFF
--- a/src/session-storage.ts
+++ b/src/session-storage.ts
@@ -1,4 +1,4 @@
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { EventEmitter } from "node:events";
 
 type SessionEvents = {

--- a/src/streamable-http.ts
+++ b/src/streamable-http.ts
@@ -1,8 +1,10 @@
+import type { AuthInfo } from "@modelcontextprotocol/sdk/server/auth/types.js";
 import type { Server } from "@modelcontextprotocol/sdk/server/index.d.ts";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { FastifyPluginAsync, FastifyReply } from "fastify";
 import { randomUUID } from "node:crypto";
+import { IncomingMessage } from "node:http";
 import { Sessions } from "./session-storage";
 
 type StreamableHttpPluginOptions =
@@ -110,7 +112,7 @@ const statefulPlugin: FastifyPluginAsync<
         return invalidSessionId(reply);
       }
 
-      await transport.handleRequest(req.raw, reply.raw, req.body);
+      await transport.handleRequest(injectAuthData(req.raw), reply.raw, req.body);
     }
   });
 
@@ -174,6 +176,15 @@ function createStatefulTransport(
   };
 
   return newTransport;
+}
+
+function injectAuthData(reqRaw: IncomingMessage & { auth?: AuthInfo },
+) {
+  const { authorization } = reqRaw.headers
+  if (authorization) {
+    reqRaw.auth = { token: authorization } as AuthInfo;
+  }
+  return reqRaw;
 }
 
 function invalidSessionId(reply: FastifyReply): void {

--- a/src/streamable-http.ts
+++ b/src/streamable-http.ts
@@ -112,7 +112,11 @@ const statefulPlugin: FastifyPluginAsync<
         return invalidSessionId(reply);
       }
 
-      await transport.handleRequest(injectAuthData(req.raw), reply.raw, req.body);
+      await transport.handleRequest(
+        injectAuthData(req.raw),
+        reply.raw,
+        req.body,
+      );
     }
   });
 
@@ -178,9 +182,8 @@ function createStatefulTransport(
   return newTransport;
 }
 
-function injectAuthData(reqRaw: IncomingMessage & { auth?: AuthInfo },
-) {
-  const { authorization } = reqRaw.headers
+function injectAuthData(reqRaw: IncomingMessage & { auth?: AuthInfo }) {
+  const { authorization } = reqRaw.headers;
   if (authorization) {
     reqRaw.auth = { token: authorization } as AuthInfo;
   }


### PR DESCRIPTION
This PR allows injecting an auth token for further usage in tool calls. It is based on https://github.com/modelcontextprotocol/typescript-sdk/pull/166 and https://github.com/modelcontextprotocol/typescript-sdk/pull/399.