### PR TITLE
Bump MCP SDK to 1.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "typescript-eslint": "^8.25.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.15.1",
+    "@modelcontextprotocol/sdk": "^1.16.0",
     "fastify": "^5.2.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -888,7 +888,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@modelcontextprotocol/sdk@npm:^1.15.1":
+"@modelcontextprotocol/sdk@npm:^1.16.0":
   version: 1.17.5
   resolution: "@modelcontextprotocol/sdk@npm:1.17.5"
   dependencies:
@@ -2514,7 +2514,7 @@ __metadata:
   resolution: "fastify-mcp@workspace:."
   dependencies:
     "@eslint/js": "npm:^9.21.0"
-    "@modelcontextprotocol/sdk": "npm:^1.15.1"
+    "@modelcontextprotocol/sdk": "npm:^1.16.0"
     "@types/jest": "npm:^29.5.14"
     "@types/node": "npm:^22.13.8"
     eslint: "npm:^9.21.0"


### PR DESCRIPTION
Upgrades the MCP SDK dependency version to 1.16.0
