### PR TITLE
Migrate package to use ESM

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,6 +4,9 @@ const config: Config = {
   clearMocks: true,
   coverageProvider: "v8",
   testEnvironment: "node",
+  moduleNameMapper: {
+    "^(\\.{1,2}/.*)\\.js$": "$1",
+  },
   transform: {
     "^.+.tsx?$": ["ts-jest", {}],
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "fastify-mcp",
   "version": "2.1.0",
+  "type": "module",
   "packageManager": "yarn@4.7.0",
   "author": {
     "name": "Kshitij Chauhan",
@@ -17,14 +18,18 @@
     "ai",
     "anthropic"
   ],
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist"
   ],
   "scripts": {
     "lint": "eslint .",
-    "test": "jest",
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "build": "tsc",
     "format": "prettier --write .",
     "format:check": "prettier --check ."

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { fastifyMCPSSE } from "./mcp-sse-plugin";
-export { Sessions } from "./session-storage";
-export { streamableHttp } from "./streamable-http";
+export { fastifyMCPSSE } from "./mcp-sse-plugin.js";
+export { Sessions } from "./session-storage.js";
+export { streamableHttp } from "./streamable-http.js";

--- a/src/mcp-sse-plugin.ts
+++ b/src/mcp-sse-plugin.ts
@@ -1,7 +1,7 @@
 import type { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { FastifyPluginCallback, FastifyRequest } from "fastify";
-import { Sessions } from "./session-storage";
+import { Sessions } from "./session-storage.js";
 
 type MCPSSEPluginOptions = {
   server: Server;
@@ -39,7 +39,7 @@ export const fastifyMCPSSE: FastifyPluginCallback<MCPSSEPluginOptions> = (
       sessions.remove(sessionId);
     });
 
-    fastify.log.info("Starting new session", { sessionId });
+    fastify.log.info({ sessionId }, "Starting new session");
     await server.connect(transport);
   });
 

--- a/src/session-storage.test.ts
+++ b/src/session-storage.test.ts
@@ -1,3 +1,4 @@
+import { jest } from "@jest/globals";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { Sessions } from "./session-storage";
 import { setTimeout } from "node:timers/promises";

--- a/src/session-storage.ts
+++ b/src/session-storage.ts
@@ -1,4 +1,4 @@
-import type { Transport } from "@modelcontextprotocol/sdk/shared/transport";
+import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import { EventEmitter } from "node:events";
 
 type SessionEvents = {

--- a/src/streamable-http.ts
+++ b/src/streamable-http.ts
@@ -3,7 +3,7 @@ import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { FastifyPluginAsync, FastifyReply } from "fastify";
 import { randomUUID } from "node:crypto";
-import { Sessions } from "./session-storage";
+import { Sessions } from "./session-storage.js";
 
 type StreamableHttpPluginOptions =
   | StatefulStreamableHttpPluginOptions

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2016",
-    "module": "commonjs",
-    "esModuleInterop": true,
+    "target": "es2022",
+    "module": "nodenext",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
See https://github.com/haroldadmin/fastify-mcp/issues/27

This PR migrates this package to build and ship as an ESM instead of CJS.
Most of the changes are fairly mechanical, except for some funky jest config.

When merged, this change should be released as a breaking change as we do not want existing CJS consumers to silently upgrade to an ESM version.
